### PR TITLE
Make it possible to change location in cart

### DIFF
--- a/src/src/classes/frontend/class-slw-frontend-cart.php
+++ b/src/src/classes/frontend/class-slw-frontend-cart.php
@@ -19,7 +19,7 @@ if( !class_exists('SlwFrontendCart') ) {
 
 	class SlwFrontendCart
 	{
-		
+
 		/**
 		 * Construct.
 		 *
@@ -66,7 +66,7 @@ if( !class_exists('SlwFrontendCart') ) {
 
 			if( !empty($stock_locations) ) {
 				echo '<label class="slw_cart_item_stock_location_label">'.__('Nearest Location', 'stock-locations-for-woocommerce').':</label>';
-				
+
 				// lock to default location if enabled
 				if( $lock_default_location && $default_location != 0 ) {
 					echo '<select class="slw_item_stock_location slw_cart_item_stock_location_selection" style="display:block;" required disabled>';
@@ -77,7 +77,7 @@ if( !class_exists('SlwFrontendCart') ) {
 
 				// default behaviour
 				if( isset($cart_item['stock_location']) ) {
-					echo '<select class="slw_item_stock_location slw_cart_item_stock_location_selection" style="display:block;" required disabled>';
+					echo '<select class="slw_item_stock_location slw_cart_item_stock_location_selection" style="display:block;" required>';
 					echo '<option disabled>'.__('Select location...', 'stock-locations-for-woocommerce').'</option>';
 				} else {
 					echo '<select class="slw_item_stock_location slw_cart_item_stock_location_selection" style="display:block;" required>';
@@ -123,7 +123,7 @@ if( !class_exists('SlwFrontendCart') ) {
 			wp_send_json( array( 'success' => 1 ) );
 			exit;
 		}
-		
+
 		/**
 		 * Save stock locations to order item meta.
 		 *
@@ -137,7 +137,7 @@ if( !class_exists('SlwFrontendCart') ) {
 				}
 			}
 		}
-		
+
 		/**
 		 * Locks the cart item location.
 		 *


### PR DESCRIPTION
Hi, our client needed the customer to be able to change locations in the cart, and honestly I think this works better.

If the customer needs to change the location due to an error (easy to make with a lot of locations), they can change in cart instead of:
1) Removing the product
2) Going back to the store
3) Find the correct product to add and making sure they add the correct location

It's just 1 line changed. Hopefully you agree, so we can keep getting updates from wp repo :)