### PR TITLE
Unblock the UI instead of forcing a page reload.

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -82,8 +82,9 @@ jQuery(document).ready(function($){
 		}else{		
 			$.blockUI({message:''});
 			$.post($(this).prop('href'), {}, function(){ 
+				$.unblockUI();
 				//document.location.href = slw_frontend.cart_url; 
-				document.location.reload();
+				//document.location.reload();
 			}); 			
 		}
 	});


### PR DESCRIPTION
Fixes page reload when adding products to cart on an archive page.

The AJAX request seems unnessessary `$.post($(this).prop('href'), {}, function(){ ` but I was not sure what implications removing that has so I left it with what I could verify.