### PR TITLE
fix: only apply to front-end when WC session is available

### DIFF
--- a/src/inc/functions.php
+++ b/src/inc/functions.php
@@ -860,7 +860,7 @@ jQuery(document).ready(function($){
 	}
 	function slw_override_stock_quantity( $quantity, $product ) {
 
-		  if ( class_exists('SLW\SRC\Helpers\SlwStockAllocationHelper') ) {
+		  if ( class_exists('SLW\SRC\Helpers\SlwStockAllocationHelper')  && !is_admin()) {
 	 
 			   $selected_stock_location_id = WC()->session->get('stock_location_selected');
 			   


### PR DESCRIPTION
Fixes #134

Session handler is only available on the front end, this code throws a fatal error on the backend product page.