### PR TITLE
Fixes undefined index when adding a product to your cart from an archive page

### DIFF
--- a/src/src/classes/frontend/class-slw-frontend-cart.php
+++ b/src/src/classes/frontend/class-slw-frontend-cart.php
@@ -204,7 +204,7 @@ if( !class_exists('SlwFrontendCart') ) {
 								
 								if( 
 									
-									is_array($cart_item['stock_location']) && array_key_exists($product_id, $cart_item['stock_location']) && $location['term_id']==$cart_item['stock_location'][$product_id] ) {
+									isset( $cart_item['stock_location'] ) && is_array($cart_item['stock_location']) && array_key_exists($product_id, $cart_item['stock_location']) && $location['term_id']==$cart_item['stock_location'][$product_id] ) {
 									$selected = 'selected="selected"';
 								}
 							} else {


### PR DESCRIPTION
If you add a product from the archive and then view your cart by default there is no stock_location index set so you get an undefined index error. I ran into this when showing the stock locations selector on the cart page.