### PR TITLE
Fix reduce stock automatic 

### DIFF
--- a/src/src/helpers/helper-slw-order-item.php
+++ b/src/src/helpers/helper-slw-order-item.php
@@ -133,7 +133,7 @@ if ( !class_exists('SlwOrderItemHelper') ) {
 		
 			// Manual allocation doesn't need to be restricted to the order stock reduced meta
 			if( $allocationType == 'auto' ) {
-				$wc_order_stock_reduced = get_post_meta( $order_id, '_order_stock_reduced', true ); // prevents reducing stock twice for the product
+				$wc_order_stock_reduced = get_post_meta( $order_id, '_slw_order_stock_reduced', true ); // prevents reducing stock twice for the product
 			} else {
 				$wc_order_stock_reduced = false;
 			}


### PR DESCRIPTION
The default wc stock of a product is not being reduced when creating an order.

I found out that in src/src/helpers/helper-slw-order-item.php on line 136 the post meta `_order_stock_reduced` returned no. But there is no `wc_string_to_bool` used so the if on line 141 will not work because `no` is a valid string. 

I saw that `_order_stock_reduced` is not used in the plugin but `_slw_order_stock_reduced` is. So I think it should be replaced with that?
