### PR TITLE
Fix inconsistent calls to slw_stock_allocation_notification_message

### DIFF
--- a/src/src/helpers/helper-slw-mail.php
+++ b/src/src/helpers/helper-slw-mail.php
@@ -40,14 +40,13 @@ if ( !class_exists('SlwMailHelper') ) {
 				$subject = __('Stock allocated in', 'stock-locations-for-woocommerce') . ' ' . $term->name;
 				$subject = apply_filters('slw_stock_allocation_notification_subject', $subject, $term, $quantity, $item);
 				
-				$slw_stock_allocation_notification_message = sprintf(__('This is an automatically generated notification informing that the quantity of <strong>%1$d</strong> was allocated for the item <strong>%2$s</strong> with the ID <strong>%3$d</strong>.', 'stock-locations-for-woocommerce'), $quantity, $item->get_name(), $item->get_id());
-				$message = apply_filters('slw_stock_allocation_notification_message', $slw_stock_allocation_notification_message, $quantity, $item->get_name(), $item->get_id());
-				
-				$body = apply_filters( 'slw_stock_allocation_notification_message', $message, $term, $quantity, $item );
+				$message = sprintf(__('This is an automatically generated notification informing that the quantity of <strong>%1$d</strong> was allocated for the item <strong>%2$s</strong> with the ID <strong>%3$d</strong>.', 'stock-locations-for-woocommerce'), $quantity, $item->get_name(), $item->get_id());
+				$message = apply_filters( 'slw_stock_allocation_notification_message', $message, $term, $quantity, $item );
+
 				$headers = array('Content-Type: text/html; charset=UTF-8');
 				add_filter('wp_mail_content_type', function( $content_type ) { return 'text/html'; }); // forces wp_mail() to use 'text/html'
 
-				$mail_output = wp_mail( $to, $subject, $body, $headers ); // try to send email
+				$mail_output = wp_mail( $to, $subject, $message, $headers ); // try to send email
 				wc_update_order_item_meta( $item->get_id(), '_slw_notification_mail_output', $mail_output );
 			}
 		}


### PR DESCRIPTION
In the mail helper, the filter for email message overriding is called twice, with different parameter types. 
See below:

https://github.com/fahadmahmood8/stock-locations-for-woocommerce/blob/7322f33ac3b7193b0261d9cc629160c1c99c2aaa/src/src/helpers/helper-slw-mail.php#L46

This removes the extra call using the same parameter types as other filters (return value, term, quantity and item) and unifies variable naming.