### PR TITLE
Fix bug with variation stock status querying

### DIFF
--- a/src/inc/functions.php
+++ b/src/inc/functions.php
@@ -1272,7 +1272,8 @@ add_action('admin_init', 'wc_slw_admin_init');
 					}
 				}
 			break;
-	
+
+			case 'variation':
 			case 'simple':
 				if ($location_id) {
 					//pree($$product_id.' - '.$location_id);
@@ -1283,7 +1284,7 @@ add_action('admin_init', 'wc_slw_admin_init');
 					//pree($stock_at_location.' - '.$instock_status);
 				} else {
 					//$all_locations = get_terms( array( 'taxonomy' => 'location', 'hide_empty' => false ) );
-					$all_locations = wc_get_product_terms($product_id, 'location', ['fields' => 'all',]);
+					$all_locations = wc_get_product_terms(($type == 'variation') ? $product_obj->get_parent_id() : $product_id, 'location', ['fields' => 'all',]);
 					$total_stock   = 0;
 					foreach ( $all_locations as $loc ) {
 						$total_stock += (float) get_post_meta( $product_id, '_stock_at_' . $loc->term_id, true );


### PR DESCRIPTION
I've recently set up this plugin on a client site and came across an issue where variations were getting their `is_in_stock` queried, and reporting incorrectly they were out of stock.

I located this down to the type of product not being handled by this plugin, so I've added support for when that happens, removing the bug.